### PR TITLE
Fix documentation typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@ const scaffoldTestFile = () => {
     if (process.argv.length < 6) {
         return console.error('invalid arguments - please specify the following arguments: myFileName, myFunction, expectedSuccessResult, expectedErrorResult')
     };
-    let filePathIndex = 3;
-    console.log('process.arv', process.argv);
+    let filePathIndex = 2;
 
     const filePath = `${process.argv[filePathIndex]}.test.js`;
     const funcName = process.argv[++filePathIndex];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "scaffolder",
-  "version": "1.0.0",
+  "name": "batten",
+  "version": "1.0.4",
   "main": "index.js",
   "bin": {
     "jester": "index.js"

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,16 @@
-# scaffolder
+# Batten
 
-CLI for rapidly building test files 
+CLI scaffolder for rapidly building test files 
 
 
-[![Known Vulnerabilities](https://snyk.io/test/npm/scaffolder/badge.svg)](https://snyk.io/test/npm/gforce)
-<a href="https://npmcharts.com/compare/scaffolder?minimal=true"><img src="https://img.shields.io/npm/dm/scaffolder.svg?sanitize=true" alt="Downloads"></a>
-<a href="https://www.npmjs.com/package/scaffolder"><img src="https://img.shields.io/npm/v/scaffolder.svg?sanitize=true" alt="Version"></a>
-<a href="https://www.npmjs.com/package/scaffolder"><img src="https://img.shields.io/npm/l/scaffolder.svg?sanitize=true" alt="License"></a>
+[![Known Vulnerabilities](https://snyk.io/test/npm/batten/badge.svg)](https://snyk.io/test/npm/batten)
+<a href="https://npmcharts.com/compare/Batten?minimal=true"><img src="https://img.shields.io/npm/dm/Batten.svg?sanitize=true" alt="Downloads"></a>
+<a href="https://www.npmjs.com/package/Batten"><img src="https://img.shields.io/npm/v/Batten.svg?sanitize=true" alt="Version"></a>
+<a href="https://www.npmjs.com/package/Batten"><img src="https://img.shields.io/npm/l/Batten.svg?sanitize=true" alt="License"></a>
 
 ## Install
 ```
-npm i scaffolder -g
+npm i batten -g
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ npm i scaffolder -g
 #### Create jest test file template
 ```js
 //cli
-scaffolder jester myfileName myFuncName myExpectedSuccessResult myExpectedErrorResult 
+jester myfileName myFuncName myExpectedSuccessResult myExpectedErrorResult 
 ```
 ```js
 //myFileName.test.js

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ npm i scaffolder -g
 #### Create jest test file template
 ```js
 //cli
-scaffolder jester myfileName myFuncName myExpectedSuccessResult myExpectedErrorResult 
+scaffolder jester myfileName myFunc myExpectedSuccessResult myExpectedErrorResult 
 ```
 ```js
 //myFileName.test.js


### PR DESCRIPTION
There is a typo in the docs - it should be either myFuncName or myFunc everywhere. Changing the command to use myFunc is cheaper.